### PR TITLE
Iframe sandbox denied scripts

### DIFF
--- a/lib/ionic.coffee
+++ b/lib/ionic.coffee
@@ -5,7 +5,7 @@ http = require("http")
 
 class WebBrowserPreviewView extends ScrollView
   @content: (params) ->
-    @iframe outlet: "frame", class: "iphone", src: params.url, sandbox: "none"
+    @iframe outlet: "frame", class: "iphone", src: params.url, sandbox: "allow-same-origin allow-scripts"
   getTitle: ->
     "Ionic: Preview"
   initialize: (params) ->


### PR DESCRIPTION
Hello guy! The preview is not show in my ionic application because the error below:

#### Blocked script execution in http://localhost:8100 because the document's frame is sandboxed and the 'allow-scripts' permission is not set

The problem was founded in Console tab from **Atom Developer Tools**. See the screen below:

![ionic-atom-iframe-error](https://cloud.githubusercontent.com/assets/431606/7105304/640b351a-e0e8-11e4-9c0a-e9e9e68a9603.png)

This error is showed because the url of the ionic application is loaded by iframe with a HTML5 attribute `sandbox="none"`, that restricts the content of iframe and blocks load scripts or request external url's like a Rest APi's! I changed the values to `sandbox="allow-same-origin allow-script"` and it works!

Reference for this solution founded in: http://www.w3schools.com/tags/att_iframe_sandbox.asp

Please, see my changes in this pull request :)